### PR TITLE
Support css inclusion

### DIFF
--- a/src/stylus.plugin.coffee
+++ b/src/stylus.plugin.coffee
@@ -9,6 +9,7 @@ module.exports = (BasePlugin) ->
 		config:
 			useNib: true
 			compress: true
+			includeCss: true
 			environments:
 				development:
 					compress: false
@@ -27,6 +28,7 @@ module.exports = (BasePlugin) ->
 				style = stylus(opts.content)
 					.set('filename', file.get('fullPath'))
 					.set('compress', @config.compress)
+					.set('include css', @config.includeCss)
 
 				# Use nib if we want to
 				if @config.useNib


### PR DESCRIPTION
Stylus can import .css files into the resulting file if this option is set to true. See https://github.com/LearnBoost/stylus/issues/448
