### PR TITLE
Updated {,dev}dependences to use the latest “minor” version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docpad-plugin-stylus",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Adds support for the Stylus CSS pre-processor to DocPad",
   "homepage": "http://docpad.org/plugin/stylus",
   "keywords": [
@@ -32,11 +32,11 @@
     "docpad": ">=6.37 <7"
   },
   "dependencies": {
-    "stylus": "~0.38.0",
-    "nib": "~1.0.1"
+    "stylus": ">=0.38 <1.x",
+    "nib": ">=1.x <2.x"
   },
   "devDependencies": {
-    "coffee-script": "~1.6.2"
+    "coffee-script": ">=1.6.x <2.x"
   },
   "main": "./out/stylus.plugin.js",
   "scripts": {


### PR DESCRIPTION
My reasoning is that the semver form `~1.1.x` is (although still useful) relatively narrow.  There have been many updates to Stylus, Nib, and CoffeeScript, but since the plugin used the `~` form for dependencies, npm never grabbed any of the newer versions.  

Since semver is so widespread, I think it’s safe to just stick to a major version.  Future minor versions will add benefit without breaking anything (since semver states that any backward-incompatible change must increment the major version number).
